### PR TITLE
Do not assign patched speak function to None

### DIFF
--- a/addon/globalPlugins/baiduTranslation/__init__.py
+++ b/addon/globalPlugins/baiduTranslation/__init__.py
@@ -179,7 +179,12 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def __del__(self):
 		speech.speech.speak = self._speak
-		self._speak = None
+		# Do not set self._speak to None.
+		# Since many add-ons can patch speech.speak and since the order in which patching and unpatching is not
+		# well established, we may end up speech.speak restored to None.
+		# See https://github.com/cary-rowen/clipboardEnhancement/pull/14/files for an example in Clipboard
+		# Enhancement add-on.
+		# self._speak = None
 
 	def terminate(self):
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(TranslationSettingsPanel)


### PR DESCRIPTION
In Clipboard Enhancement add-on, it has been found that resetting the patched speak function to None while terminating the global plugin led to very bad result (no speech) when reinitializing add-ons; see https://github.com/cary-rowen/clipboardEnhancement/ for more details.

Since I have seen that Baidu translation add-on also resets its patch function to `None` when the global plugin is deleted, I suggest to remove it.
For now, that's just a precaution, because I am not aware of an add-on patching `speech.speak` for which Baidu Translation add-on would cause an issue; maybe it's just because Baidu is the first in alphabetic sorting that patches `speech.speak`.

Please also note that with NVDA 2024.2, there will be an extension point in `speech.speak` to filter its speech sequence. This will need to be used in add-ons as a more robust customization of `speech.speak`.
